### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/secrets-test.yml
+++ b/.github/workflows/secrets-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: google/secrets-sync-action@v1.7.0
+      - uses: jpoehnelt/secrets-sync-action@v1.7.0
         with:
           SECRETS: |
             ^FOO$


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.